### PR TITLE
Pickup effects

### DIFF
--- a/Assets/Prefabs/Pickup.meta
+++ b/Assets/Prefabs/Pickup.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1b4a34bb8322cb439edc5f11aace92f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Pickup/TofuSpeedpickup.prefab
+++ b/Assets/Prefabs/Pickup/TofuSpeedpickup.prefab
@@ -1,0 +1,286 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1278698564524626}
+  m_IsPrefabAsset: 1
+--- !u!1 &1189817698204488
+GameObject:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4493402274023582}
+  m_Layer: 0
+  m_Name: B_spine_2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1278698564524626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4559597248973560}
+  - component: {fileID: 95211680742559532}
+  - component: {fileID: 54572544610376278}
+  - component: {fileID: 65439145495804880}
+  m_Layer: 0
+  m_Name: TofuSpeedpickup
+  m_TagString: Pickup
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1353227700047068
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4377345368203010}
+  - component: {fileID: 137838050747611084}
+  m_Layer: 0
+  m_Name: mesh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1632803842284632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4184632414560034}
+  m_Layer: 0
+  m_Name: root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1660889055933256
+GameObject:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4328903438872340}
+  m_Layer: 0
+  m_Name: B_spine_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1827589837527938
+GameObject:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4968356159859236}
+  m_Layer: 0
+  m_Name: B_spine_end
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4184632414560034
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1632803842284632}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4328903438872340}
+  m_Father: {fileID: 4559597248973560}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4328903438872340
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1660889055933256}
+  m_LocalRotation: {x: 0.7071068, y: -0.00000028378975, z: -0.7071068, w: -0.00000028378975}
+  m_LocalPosition: {x: -2.715127e-10, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4493402274023582}
+  m_Father: {fileID: 4184632414560034}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4377345368203010
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1353227700047068}
+  m_LocalRotation: {x: 0.000000021855694, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.01, y: 0.01, z: 0.01}
+  m_Children: []
+  m_Father: {fileID: 4559597248973560}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4493402274023582
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1189817698204488}
+  m_LocalRotation: {x: 0.00000011920929, y: 2.842171e-14, z: 0.00000023841858, w: 1}
+  m_LocalPosition: {x: -0.24053206, y: -2.1793742e-16, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4968356159859236}
+  m_Father: {fileID: 4328903438872340}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4559597248973560
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1278698564524626}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.90160227, y: 0.52, z: 18.094692}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4377345368203010}
+  - {fileID: 4184632414560034}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4968356159859236
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1827589837527938}
+  m_LocalRotation: {x: -1.5257764e-15, y: -5.1096346e-17, z: 0.004851561, w: 0.99998826}
+  m_LocalPosition: {x: -0.40946794, y: 0.00000012824961, z: -2.2176705e-14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4493402274023582}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &54572544610376278
+Rigidbody:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1278698564524626}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 80
+  m_CollisionDetection: 0
+--- !u!65 &65439145495804880
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1278698564524626}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.69, y: 0.5779338, z: 1}
+  m_Center: {x: 0, y: 0.30485702, z: 0}
+--- !u!95 &95211680742559532
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1278698564524626}
+  m_Enabled: 1
+  m_Avatar: {fileID: 9000000, guid: edb96520f0ebe7245b94123e8ae15f94, type: 3}
+  m_Controller: {fileID: 9100000, guid: 06e57a9707a9e40399f6ff5834c13906, type: 2}
+  m_CullingMode: 1
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!137 &137838050747611084
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1353227700047068}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: df40c4f2e593a87449838a89c7ccb6bc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300000, guid: edb96520f0ebe7245b94123e8ae15f94, type: 3}
+  m_Bones:
+  - {fileID: 4493402274023582}
+  - {fileID: 4968356159859236}
+  - {fileID: 4328903438872340}
+  - {fileID: 4184632414560034}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 4184632414560034}
+  m_AABB:
+    m_Center: {x: 0.000000059604645, y: -0.008165538, z: 0.42163974}
+    m_Extent: {x: 0.38647777, y: 0.5342333, z: 0.42476732}
+  m_DirtyAABB: 0

--- a/Assets/Prefabs/Pickup/TofuSpeedpickup.prefab.meta
+++ b/Assets/Prefabs/Pickup/TofuSpeedpickup.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 145dd5b1e3f241a42b9cb8de73da8977
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -739,6 +739,69 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 228975679}
   m_Script: {fileID: 11500000, guid: 4aacdbef68ee48c43adb126bbbd07dfc, type: 3}
+--- !u!1001 &346008023
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -1.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 18.094692
+      objectReference: {fileID: 0}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1278698564524626, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+      propertyPath: m_Name
+      value: TofuHealthPickup
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
+  m_IsPrefabAsset: 0
+--- !u!1 &346008024 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1278698564524626, guid: 145dd5b1e3f241a42b9cb8de73da8977,
+    type: 2}
+  m_PrefabInternal: {fileID: 346008023}
+--- !u!114 &346008025
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 346008024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c5e0421c14dd21439dbfca50b7520c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HealthToGive: 1
 --- !u!1 &453468707
 GameObject:
   m_ObjectHideFlags: 0
@@ -5895,6 +5958,75 @@ CanvasRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1144352056}
   m_CullTransparentMesh: 0
+--- !u!1 &1206443335
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1206443336}
+  - component: {fileID: 1206443338}
+  - component: {fileID: 1206443337}
+  m_Layer: 5
+  m_Name: LifeIcon4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1206443336
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1206443335}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
+  m_Children: []
+  m_Father: {fileID: 1865644595}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -92.8, y: -3.049347}
+  m_SizeDelta: {x: 33.8, y: 40.5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1206443337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1206443335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: a2906c73b91eb4eb68223ee59756dccf, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1206443338
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1206443335}
+  m_CullTransparentMesh: 0
 --- !u!1 &1238509713
 GameObject:
   m_ObjectHideFlags: 0
@@ -6484,6 +6616,7 @@ RectTransform:
   - {fileID: 1144352057}
   - {fileID: 1879054779}
   - {fileID: 2110242043}
+  - {fileID: 1206443336}
   m_Father: {fileID: 1238509717}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6507,6 +6640,7 @@ MonoBehaviour:
   - {fileID: 1144352056}
   - {fileID: 1879054778}
   - {fileID: 2110242042}
+  - {fileID: 1206443335}
 --- !u!114 &1865644597
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -185,82 +185,6 @@ CanvasRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 21754022}
   m_CullTransparentMesh: 0
---- !u!1001 &72770387
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4169263262985390, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4169263262985390, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4169263262985390, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 6.92
-      objectReference: {fileID: 0}
-    - target: {fileID: 4169263262985390, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4169263262985390, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4169263262985390, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4169263262985390, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4169263262985390, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1259604870327842, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 198385226101371780, guid: cdb133dcc96b4c34781e20021b33ebb9,
-        type: 2}
-      propertyPath: EmissionModule.rateOverTime.scalar
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 198385226101371780, guid: cdb133dcc96b4c34781e20021b33ebb9,
-        type: 2}
-      propertyPath: ColorModule.enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 198385226101371780, guid: cdb133dcc96b4c34781e20021b33ebb9,
-        type: 2}
-      propertyPath: ColorModule.gradient.maxGradient.key1.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 198385226101371780, guid: cdb133dcc96b4c34781e20021b33ebb9,
-        type: 2}
-      propertyPath: ColorModule.gradient.maxGradient.atime1
-      value: 49151
-      objectReference: {fileID: 0}
-    - target: {fileID: 198385226101371780, guid: cdb133dcc96b4c34781e20021b33ebb9,
-        type: 2}
-      propertyPath: ColorModule.gradient.maxGradient.atime2
-      value: 65535
-      objectReference: {fileID: 0}
-    - target: {fileID: 198385226101371780, guid: cdb133dcc96b4c34781e20021b33ebb9,
-        type: 2}
-      propertyPath: ColorModule.gradient.maxGradient.m_NumAlphaKeys
-      value: 3
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: cdb133dcc96b4c34781e20021b33ebb9, type: 2}
-  m_IsPrefabAsset: 0
 --- !u!1 &110789943
 GameObject:
   m_ObjectHideFlags: 0
@@ -5449,7 +5373,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: -75, y: 0, z: 0}
 --- !u!1 &483211426
 GameObject:
@@ -5676,45 +5600,59 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 460484, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
       propertyPath: m_LocalPosition.x
       value: 0.90160227
       objectReference: {fileID: 0}
-    - target: {fileID: 460484, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
       propertyPath: m_LocalPosition.y
       value: 0.52
       objectReference: {fileID: 0}
-    - target: {fileID: 460484, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
       propertyPath: m_LocalPosition.z
       value: 18.094692
       objectReference: {fileID: 0}
-    - target: {fileID: 460484, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 460484, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 460484, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 460484, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 460484, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
+    - target: {fileID: 4559597248973560, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5422046, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
-      propertyPath: m_UseGravity
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c2fb9cafd421b4bad8287429760d70c4, type: 2}
+  m_SourcePrefab: {fileID: 100100000, guid: 145dd5b1e3f241a42b9cb8de73da8977, type: 2}
   m_IsPrefabAsset: 0
+--- !u!1 &707680334 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1278698564524626, guid: 145dd5b1e3f241a42b9cb8de73da8977,
+    type: 2}
+  m_PrefabInternal: {fileID: 656326855}
+--- !u!114 &707680339
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 707680334}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b830e5982b2fe47468f701c1499fd03d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  duration: 3
+  speedAddition: 20
 --- !u!1 &926683723
 GameObject:
   m_ObjectHideFlags: 0
@@ -6406,7 +6344,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1822425479
 MonoBehaviour:
@@ -6694,21 +6632,17 @@ CharacterController:
   m_SkinWidth: 0.03
   m_MinMoveDistance: 0.001
   m_Center: {x: 0, y: 0.7, z: 0}
---- !u!54 &1959863896
-Rigidbody:
+--- !u!114 &1959863895
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1959863893}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3503eee3999d2c6458d63ebd0a07a55d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &1959863897 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 478232, guid: a780da896ca904035b33f90d86b0ba4d,

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -16,10 +16,10 @@ public class GameController : MonoBehaviour {
 		scoreLabel.text = "Score : " + score + "m";
 
 		// Update Life Panel
-		lifePanel.UpdateLife(nejiko.Life());
+		lifePanel.UpdateLife(nejiko.Life);
 
 		// Close game when life count become 0
-		if (nejiko.Life () <= 0) {
+		if (nejiko.Life <= 0) {
 			// Stop more update
 			enabled = false;
 

--- a/Assets/Scripts/NejikoController.cs
+++ b/Assets/Scripts/NejikoController.cs
@@ -12,7 +12,7 @@ public class NejikoController : MonoBehaviour {
 
     [SerializeField] static List<Effect_Base> effectList = new List<Effect_Base>();
 
-    internal static void AddEffect<T>(float duration, float arguments) where T : Effect_Base
+    public void AddEffect<T>(float duration, float arguments) where T : Effect_Base
     {
         T effect = (T) Activator.CreateInstance(typeof(T), duration, arguments);
         effectList.Add(effect);
@@ -103,15 +103,21 @@ public class NejikoController : MonoBehaviour {
         animator.SetBool("run", moveDirection.z > 0.0f);
 
         // Update Effects
+	    List<Effect_Base> toRemove = new List<Effect_Base>();
         foreach(Effect_Base effect in effectList)
         {
             effect.PowerUpUpdate();
-            if(effect.remainingTime <= 0)
+            if (effect.remainingTime <= 0)
             {
                 effect.EffectEnd();
-                effectList.Remove(effect);
+                toRemove.Add(effect);
             }
         }
+
+	    foreach (Effect_Base remove in toRemove)
+	    {
+	        effectList.Remove(remove);
+	    }
     }
 
 	// Start moving to Left Lane

--- a/Assets/Scripts/NejikoController.cs
+++ b/Assets/Scripts/NejikoController.cs
@@ -12,11 +12,15 @@ public class NejikoController : MonoBehaviour {
 
     [SerializeField] static List<Effect_Base> effectList = new List<Effect_Base>();
 
-    public void AddEffect<T>(float duration, float arguments) where T : Effect_Base
+    public void AddEffect<T>(T effect) where T : Effect_Base
     {
-        T effect = (T) Activator.CreateInstance(typeof(T), duration, arguments);
         effectList.Add(effect);
-        effect.EffectStart(duration);
+        StartCoroutine(EffectEnumerator(effect));
+    }
+
+    public void RemoveEffect<T>(T effect) where T : Effect_Base
+    {
+        effectList.Remove(effect);
     }
 
     CharacterController controller;
@@ -24,7 +28,12 @@ public class NejikoController : MonoBehaviour {
 
 	Vector3 moveDirection = Vector3.zero;
 	int targetLane;
-	int life = DefaultLife;
+	private int life = DefaultLife;
+    public int Life
+    {
+        get { return life; }
+        set { life = value; }
+    }
 	float recoverTime = 0.0f;
 
 	[SerializeField] public float gravity;
@@ -39,10 +48,6 @@ public class NejikoController : MonoBehaviour {
 
     // Shake Camera
     public CameraShake cameraShake;
-
-    public int Life() {
-		return life;
-	}
 
 	public bool IsStunned() {
 		return recoverTime > 0.0f || life <= 0;
@@ -101,23 +106,6 @@ public class NejikoController : MonoBehaviour {
 
         // If the speed is more than 0, the running flag is set to true.
         animator.SetBool("run", moveDirection.z > 0.0f);
-
-        // Update Effects
-	    List<Effect_Base> toRemove = new List<Effect_Base>();
-        foreach(Effect_Base effect in effectList)
-        {
-            effect.PowerUpUpdate();
-            if (effect.remainingTime <= 0)
-            {
-                effect.EffectEnd();
-                toRemove.Add(effect);
-            }
-        }
-
-	    foreach (Effect_Base remove in toRemove)
-	    {
-	        effectList.Remove(remove);
-	    }
     }
 
 	// Start moving to Left Lane
@@ -151,12 +139,26 @@ public class NejikoController : MonoBehaviour {
 
 	}
 
+    private IEnumerator EffectEnumerator(Effect_Base effect)
+    {
+        effect.EffectStart(this);
+        float time = effect.remainingTime;
+        while (time >= 0)
+        {
+            effect.EffectUpdate(this);
+            time -= Time.deltaTime;
+            yield return null;
+        }
+        effect.EffectEnd(this);
+        RemoveEffect(effect);
+    }
+
 	// When generated crash to CharacterController
 	void OnControllerColliderHit(ControllerColliderHit hit) {
 		if (IsStunned ())
 			return;
 
-		if (hit.gameObject.tag == "Robo") {
+		if (hit.gameObject.CompareTag("Robo")) {
 			// Reduce life value, and change state to sleep
 			life --;
 			recoverTime = StunDuration;

--- a/Assets/Scripts/PickUps/Effect/Effect_Base.cs
+++ b/Assets/Scripts/PickUps/Effect/Effect_Base.cs
@@ -2,20 +2,16 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public abstract class Effect_Base {
-    
+public abstract class Effect_Base
+{
     public float remainingTime = 0;    
 
-    public Effect_Base(float duration, float argument)
+    protected Effect_Base(float duration)
     {
         remainingTime = duration;
     }
-    
-    public void PowerUpUpdate()
-    {
-        remainingTime -= Time.deltaTime;
-    }
-
-    public abstract void EffectStart(float duration);
-    public abstract void EffectEnd();
+   
+    public abstract void EffectStart(NejikoController controller);
+    public abstract void EffectUpdate(NejikoController controller);
+    public abstract void EffectEnd(NejikoController controller);
 }

--- a/Assets/Scripts/PickUps/Effect/Effect_Health.cs
+++ b/Assets/Scripts/PickUps/Effect/Effect_Health.cs
@@ -1,0 +1,27 @@
+﻿namespace PickUps.Effect
+{
+    public class Effect_Health : Effect_Base
+    {
+        private int healthValue;
+
+        public Effect_Health(int healthToGive) : base(0)
+        {
+            healthValue = healthToGive;
+        }
+
+        public override void EffectStart(NejikoController controller)
+        {
+            controller.Life += healthValue;
+        }
+
+        public override void EffectUpdate(NejikoController controller)
+        {
+            
+        }
+
+        public override void EffectEnd(NejikoController controller)
+        {
+            
+        }
+    }
+}

--- a/Assets/Scripts/PickUps/Effect/Effect_Health.cs.meta
+++ b/Assets/Scripts/PickUps/Effect/Effect_Health.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab57512179a70664bbebfe4ce5d3d5a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PickUps/Effect/Effect_Speed.cs
+++ b/Assets/Scripts/PickUps/Effect/Effect_Speed.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Assets/Scripts/PickUps/Effect/Effect_Speed.cs
+++ b/Assets/Scripts/PickUps/Effect/Effect_Speed.cs
@@ -7,18 +7,23 @@ public class Effect_Speed : Effect_Base
 {
     public float speed;
 
-    public Effect_Speed(float duration, float argument) : base(duration, argument)
+    public Effect_Speed(float duration, float argument) : base(duration)
     {
         speed = argument;
     }
 
-    public override void EffectStart(float duration)
+    public override void EffectStart(NejikoController controller)
     {
-        GlobalInfo.NejikoController.speedZ += speed;
+        controller.speedZ += speed;
     }
 
-    public override void EffectEnd()
+    public override void EffectUpdate(NejikoController controller)
     {
-        GlobalInfo.NejikoController.speedZ -= speed;
+        
+    }
+
+    public override void EffectEnd(NejikoController controller)
+    {
+        controller.speedZ -= speed;
     }
 }

--- a/Assets/Scripts/PickUps/PowerUp/PowerUp_Base.cs
+++ b/Assets/Scripts/PickUps/PowerUp/PowerUp_Base.cs
@@ -9,5 +9,5 @@ public abstract class PowerUp_Base : MonoBehaviour {
 	}
 
     public abstract void OnCollisionEnter(Collision hit);
-
+    public abstract void GiveEffect(NejikoController controller);
 }

--- a/Assets/Scripts/PickUps/PowerUp/PowerUp_Base.cs
+++ b/Assets/Scripts/PickUps/PowerUp/PowerUp_Base.cs
@@ -2,12 +2,20 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public abstract class PowerUp_Base : MonoBehaviour {
-	
-	// Update is called once per frame
-	void Update () {
-	}
+public abstract class PowerUp_Base : MonoBehaviour
+{
 
-    public abstract void OnCollisionEnter(Collision hit);
-    public abstract void GiveEffect(NejikoController controller);
+    private Effect_Base effect;
+
+    void Start()
+    {
+        effect = InitEffect();
+    }
+
+    protected abstract Effect_Base InitEffect();
+    
+    public void GiveEffect(NejikoController controller)
+    {
+        controller.AddEffect(effect);
+    }
 }

--- a/Assets/Scripts/PickUps/PowerUp/PowerUp_Health.cs
+++ b/Assets/Scripts/PickUps/PowerUp/PowerUp_Health.cs
@@ -1,0 +1,15 @@
+﻿using PickUps.Effect;
+using UnityEngine;
+
+namespace PickUps.PowerUp
+{
+    public class PowerUp_Health : PowerUp_Base
+    {
+        [SerializeField] private int HealthToGive = 1;
+
+        protected override Effect_Base InitEffect()
+        {
+            return new Effect_Health(HealthToGive);
+        }
+    }
+}

--- a/Assets/Scripts/PickUps/PowerUp/PowerUp_Health.cs.meta
+++ b/Assets/Scripts/PickUps/PowerUp/PowerUp_Health.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c5e0421c14dd21439dbfca50b7520c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PickUps/PowerUp/PowerUp_Speed.cs
+++ b/Assets/Scripts/PickUps/PowerUp/PowerUp_Speed.cs
@@ -12,4 +12,9 @@ public class PowerUp_Speed : PowerUp_Base
     {
         Debug.Log(hit.gameObject.name);
     }
+
+    public override void GiveEffect(NejikoController controller)
+    {
+        controller.AddEffect<Effect_Speed>(duration, speedAddition);
+    }
 }

--- a/Assets/Scripts/PickUps/PowerUp/PowerUp_Speed.cs
+++ b/Assets/Scripts/PickUps/PowerUp/PowerUp_Speed.cs
@@ -4,17 +4,11 @@ using UnityEngine;
 
 public class PowerUp_Speed : PowerUp_Base
 {
-
     [SerializeField] private float duration;
     [SerializeField] private float speedAddition;
 
-    public override void OnCollisionEnter(Collision hit)
+    protected override Effect_Base InitEffect()
     {
-        Debug.Log(hit.gameObject.name);
-    }
-
-    public override void GiveEffect(NejikoController controller)
-    {
-        controller.AddEffect<Effect_Speed>(duration, speedAddition);
+        return new Effect_Speed(duration, speedAddition);
     }
 }

--- a/Assets/Scripts/PickupCollide.cs
+++ b/Assets/Scripts/PickupCollide.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PickupCollide : MonoBehaviour
+{
+
+    private NejikoController controller;
+
+    private void Start()
+    {
+        controller = GetComponent<NejikoController>();
+    }
+
+    private void OnControllerColliderHit(ControllerColliderHit hit)
+    {
+        if (hit.gameObject.CompareTag("Pickup"))
+        {
+            PowerUp_Base powerupComp = hit.gameObject.GetComponent<PowerUp_Base>();
+            powerupComp.GiveEffect(controller);
+            Destroy(hit.gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/PickupCollide.cs.meta
+++ b/Assets/Scripts/PickupCollide.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3503eee3999d2c6458d63ebd0a07a55d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Robo
+  - Pickup
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Pickups can be picked up

------------------------------------
 Major PowerUp Architectual Changes

* PowerUps are now responsible for giving the proper arguments. That way it can initialize the effect with the exact parameters it needs.
* Effects are now managed by Coroutines. I contemplated whether it was better to put the Coroutines in the Effect_Base or in NejikoController. I'm still not sure. I AM leaning toward having it all managed by the Effect itself, so it might be moved there later.
* Effect subclasses must now implement EffectUpdate.
* Remove argument parameter from Effect_Base. It's not using it.
* Effect Start,Update,End methods pass in a NejikoController instance for use. Feel free to ignore this and just use the GlobalInfo.Controller instance. It's the exact same thing.
* NejikoController's AddEffect() now require an actual Effect object.

Other Things
* Added Health powerup/effect
* Change Life() to Life {get; set;}
* Add support for another heart.